### PR TITLE
feat: add subgraph env variables

### DIFF
--- a/lib/yearn-api-stack.ts
+++ b/lib/yearn-api-stack.ts
@@ -56,6 +56,7 @@ export class YearnAPIECSStack extends Stack {
             FASTIFY_ADDRESS: "0.0.0.0",
             NODE_ENV: "production",
             REQUEST_TIMEOUT: "1000",
+            MAINNET_SUBGRAPH_ID: "5xMSe3wTNLgFQqsAc5SCVVwT4MiRb5AogJCuSN9PjzXF",
           },
           secrets: {
             WEB3_HTTP_PROVIDER: ecs.Secret.fromSecretsManager(
@@ -85,6 +86,10 @@ export class YearnAPIECSStack extends Stack {
             ZAPPER_API_KEY: ecs.Secret.fromSecretsManager(
               servicesStack.secretsManager,
               "ZAPPER_API_KEY"
+            ),
+            SUBGRAPH_API_KEY: ecs.Secret.fromSecretsManager(
+              servicesStack.secretsManager,
+              "SUBGRAPH_API_KEY"
             ),
           },
         },


### PR DESCRIPTION
Needed to support new version of the SDK, where we are migrating away from the hosted subgraph, to the decentralized one, where you have to provide an api key