### PR TITLE
fix: correct subgraph env variable

### DIFF
--- a/lib/services-stack.ts
+++ b/lib/services-stack.ts
@@ -41,7 +41,6 @@ export class YearnAPIServicesStack extends Stack {
           REMOTE_WRITE_PASSWORD: "",
           SENTRY_DSN: "",
           ZAPPER_API_KEY: "",
-          SUBGRAPH_API_KEY: "",
         }),
         // This is a require property, but we won't actually use it.
         generateStringKey: "_",

--- a/lib/yearn-api-stack.ts
+++ b/lib/yearn-api-stack.ts
@@ -56,7 +56,6 @@ export class YearnAPIECSStack extends Stack {
             FASTIFY_ADDRESS: "0.0.0.0",
             NODE_ENV: "production",
             REQUEST_TIMEOUT: "1000",
-            MAINNET_SUBGRAPH_ID: "5xMSe3wTNLgFQqsAc5SCVVwT4MiRb5AogJCuSN9PjzXF",
           },
           secrets: {
             WEB3_HTTP_PROVIDER: ecs.Secret.fromSecretsManager(
@@ -87,9 +86,9 @@ export class YearnAPIECSStack extends Stack {
               servicesStack.secretsManager,
               "ZAPPER_API_KEY"
             ),
-            SUBGRAPH_API_KEY: ecs.Secret.fromSecretsManager(
+            MAINNET_SUBGRAPH_ENDPOINT: ecs.Secret.fromSecretsManager(
               servicesStack.secretsManager,
-              "SUBGRAPH_API_KEY"
+              "MAINNET_SUBGRAPH_ENDPOINT"
             ),
           },
         },


### PR DESCRIPTION
The SDK subgraph configuration no longer takes the subgraph id and key, rather the whole endpoint. 